### PR TITLE
Assume disconnected state on load

### DIFF
--- a/src/store/connection/connection.slice.test.ts
+++ b/src/store/connection/connection.slice.test.ts
@@ -1,6 +1,10 @@
 import { connectionActions, connectionReducer, ConnectionState } from './connection.slice';
 
 describe('connection reducer', () => {
+  it('starts disconnected', () => {
+    expect(connectionReducer(undefined, { type: 'init' } as any)).toEqual({ connected: false });
+  });
+
   it('sets connection flag', () => {
     const state: ConnectionState = { connected: true };
     const action = connectionActions.setConnected(false);

--- a/src/store/connection/connection.slice.ts
+++ b/src/store/connection/connection.slice.ts
@@ -5,7 +5,7 @@ export interface ConnectionState {
 }
 
 const initialState: ConnectionState = {
-  connected: true,
+  connected: false,
 };
 
 const connectionSlice = createSlice({

--- a/src/test/utils/test.utils.tsx
+++ b/src/test/utils/test.utils.tsx
@@ -32,15 +32,19 @@ export const startFakeTimer = () => {
   return advanceTime;
 };
 
-export const render = (ui: React.ReactElement, path = '/test/recorder', persistState = false, isLeader = true, isConnected = true) => {
+export const render = (
+  ui: React.ReactElement,
+  path = '/test/recorder',
+  persistState = false,
+  isLeader = true,
+  isConnected = true
+) => {
   const history = createMemoryHistory({ initialEntries: [path] });
   const store = createStore(history, persistState);
   if (isLeader) {
     store.dispatch(leaderActions.setLeader(true));
   }
-  if (!isConnected) {
-    store.dispatch(connectionActions.setConnected(false));
-  }
+  store.dispatch(connectionActions.setConnected(isConnected));
 
   const Wrapper: React.FC = ({ children }) => (
     <Router history={history}>


### PR DESCRIPTION
## Summary
- Start the connection state as disconnected when hydrating the store
- Ensure test utils explicitly set connected state
- Cover default disconnection with unit tests

## Testing
- `npm test --silent 2>&1 | tail -n 20`


------
https://chatgpt.com/codex/tasks/task_e_68c492477d888328902d2c223327d4bc