### PR TITLE
Show offline background when disconnected

### DIFF
--- a/src/components/layout/layout.component.tsx
+++ b/src/components/layout/layout.component.tsx
@@ -10,11 +10,10 @@ import { AppState } from '../../store/root.reducer';
 
 export const Layout: React.FC = () => {
   const status = useSelector(timerSelectors.getStatus);
-  const isLeader = useSelector((state: AppState) => state.leader.isLeader);
   const connected = useSelector((state: AppState) => state.connection.connected);
 
   return (
-    <StyledLayout status={status} offline={!connected && !isLeader} data-testid="layout">
+    <StyledLayout status={status} offline={!connected} data-testid="layout">
       <section>
         <Header />
       </section>

--- a/src/test/app.test.tsx
+++ b/src/test/app.test.tsx
@@ -49,6 +49,14 @@ describe('App tests', () => {
     expect(layout).toHaveStyle('background-color: #217e70');
   });
 
+  test('dims the background when the leader is disconnected', () => {
+    render(<App />, '/test/recorder', false, true, false);
+
+    const layout = screen.getByTestId('layout');
+
+    expect(layout).toHaveStyle('background-color: #217e70');
+  });
+
   test('applies focus styles when hitting tab and removes them when using a mouse', () => {
     const { baseElement } = render(<App />);
 


### PR DESCRIPTION
## Summary
- Update layout to always apply the offline color whenever the socket connection drops
- Add regression test verifying the leader view dims when disconnected

## Testing
- `CI=true npm test`


------
https://chatgpt.com/codex/tasks/task_e_68c493ee9ba083288f51ea7719709001