### PR TITLE
Set NODE_OPTIONS for npm build in CI

### DIFF
--- a/.github/workflows/master_contraction-timer-api.yml
+++ b/.github/workflows/master_contraction-timer-api.yml
@@ -23,11 +23,16 @@ jobs:
         with:
           node-version: '22.x'
 
-      - name: npm install, build, and test
-        run: |
-          npm install
-          npm run build --if-present
-          npm run test --if-present
+      - name: npm install
+        run: npm install
+
+      - name: npm run build
+        run: npm run build --if-present
+        env:
+          NODE_OPTIONS: --openssl-legacy-provider
+
+      - name: npm test
+        run: npm run test --if-present
 
       - name: Upload artifact for deployment job
         uses: actions/upload-artifact@v4


### PR DESCRIPTION
## Summary
- ensure the GitHub Actions build step runs with NODE_OPTIONS=--openssl-legacy-provider so npm build works with OpenSSL changes

## Testing
- not run (not required)


------
https://chatgpt.com/codex/tasks/task_e_68c893cbf6e88328ab9e92276a6de166