### PR TITLE
Set Node legacy provider for Azure Static Web Apps build

### DIFF
--- a/.github/workflows/azure-static-web-apps-brave-rock-0519d330f.yml
+++ b/.github/workflows/azure-static-web-apps-brave-rock-0519d330f.yml
@@ -35,6 +35,8 @@ jobs:
       - name: Build And Deploy
         id: builddeploy
         uses: Azure/static-web-apps-deploy@v1
+        env:
+          NODE_OPTIONS: --openssl-legacy-provider
         with:
           azure_static_web_apps_api_token: ${{ secrets.AZURE_STATIC_WEB_APPS_API_TOKEN_BRAVE_ROCK_0519D330F }}
           action: "upload"


### PR DESCRIPTION
## Summary
- set NODE_OPTIONS to use the OpenSSL legacy provider when running the Azure Static Web Apps build step

## Testing
- not run (workflow change)


------
https://chatgpt.com/codex/tasks/task_e_68c894a1c8c8832895ad28bad5b17b7a