### PR TITLE
Limit API deployment to server changes

### DIFF
--- a/.github/workflows/master_contraction-timer-api.yml
+++ b/.github/workflows/master_contraction-timer-api.yml
@@ -7,6 +7,9 @@ on:
   push:
     branches:
       - master
+    paths:
+      - 'server/**'
+      - '.github/workflows/master_contraction-timer-api.yml'
   workflow_dispatch:
 
 jobs:


### PR DESCRIPTION
## Summary
- restrict the contraction-timer API GitHub Actions workflow to run only when files in the server directory (or the workflow itself) change

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68c89f0f15248328839f831817176792