### PR TITLE
Add health check endpoint and update deployment triggers

### DIFF
--- a/.github/workflows/azure-static-web-apps-brave-rock-0519d330f.yml
+++ b/.github/workflows/azure-static-web-apps-brave-rock-0519d330f.yml
@@ -4,10 +4,20 @@ on:
   push:
     branches:
       - master
+    paths:
+      - 'src/**'
+      - 'public/**'
+      - 'package.json'
+      - 'package-lock.json'
   pull_request:
     types: [opened, synchronize, reopened, closed]
     branches:
       - master
+    paths:
+      - 'src/**'
+      - 'public/**'
+      - 'package.json'
+      - 'package-lock.json'
 
 jobs:
   build_and_deploy_job:

--- a/README.md
+++ b/README.md
@@ -47,6 +47,6 @@ Run the client, server and Redis locally:
 docker compose up
 ```
 
-The app will be available at http://localhost:3000 and the Socket.IO server at http://localhost:3001.
+The app will be available at http://localhost:3000 and the Socket.IO server at http://localhost:3001 (or the value of the `PORT` environment variable).
 
 Redis caching is optional; provide a `REDIS_HOST` environment variable for the server if you want to persist state to Redis.

--- a/server/index.ts
+++ b/server/index.ts
@@ -35,6 +35,14 @@ interface LobbyState {
 const app = express();
 app.use(cors());
 const server = http.createServer(app);
+
+function handleHealthCheck(_req: Request, res: Response): void {
+  res.status(200).json({ status: 'ok' });
+}
+
+app.get('/', handleHealthCheck);
+app.get('/healthz', handleHealthCheck);
+app.get('/ping', handleHealthCheck);
 const io = new Server(server, {
   cors: { origin: '*' },
 });
@@ -301,7 +309,10 @@ async function startServer() {
 
   io.on('connection', handleSocketConnection);
 
-  const PORT = process.env.PORT || 3001;
+  const DEFAULT_PORT = 3001;
+  const envPort = process.env.PORT;
+  const parsedPort = envPort === undefined ? NaN : Number.parseInt(envPort, 10);
+  const PORT = Number.isNaN(parsedPort) || parsedPort <= 0 ? DEFAULT_PORT : parsedPort;
   function logServerListening(): void {
     logger.info({ port: PORT }, 'Socket server listening');
   }


### PR DESCRIPTION
## Summary
- add an HTTP health check endpoint so the server responds on the configured port
- default the backend and tooling to use port 3001 when `PORT` is unset, while still honoring the environment variable
- restrict the static web app deployment workflow to run only when frontend assets change

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68c8dfe40500832895f79ffea5c51622