### PR TITLE
Fix server deployment artifact packaging

### DIFF
--- a/.github/workflows/master_contraction-timer-api.yml
+++ b/.github/workflows/master_contraction-timer-api.yml
@@ -28,7 +28,7 @@ jobs:
           cache: 'npm'
 
       - name: Install dependencies
-        run: npm install
+        run: npm ci
 
       - name: Build with Parcel
         run: npm run build --if-present
@@ -38,11 +38,16 @@ jobs:
       - name: Run tests
         run: npm test --if-present
 
-      - name: Upload server folder
+      - name: Create deployment archive
+        run: |
+          rm -rf node_modules .parcel-cache
+          zip -r ../contraction-timer-api.zip . -x "*.git*"
+
+      - name: Upload deployment artifact
         uses: actions/upload-artifact@v4
         with:
           name: node-app
-          path: server
+          path: contraction-timer-api.zip
 
   deploy:
     runs-on: ubuntu-latest
@@ -56,7 +61,7 @@ jobs:
         uses: actions/download-artifact@v4
         with:
           name: node-app
-          path: .
+          path: ./node-app
 
       - name: Login to Azure
         uses: azure/login@v2
@@ -70,4 +75,4 @@ jobs:
         with:
           app-name: 'contraction-timer-api'
           slot-name: 'Production'
-          package: server
+          package: node-app/contraction-timer-api.zip


### PR DESCRIPTION
## Summary
- package the server workflow output as a dedicated archive so the backend package.json sits at the deployment root
- adjust the deployment job to consume the archive and install dependencies with `npm ci` for reproducible builds

## Testing
- not run (workflow change only)


------
https://chatgpt.com/codex/tasks/task_e_68c92e2e366c83289af55f39ef76eabc