### PR TITLE
Add Docker deployment for server App Service

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,13 @@
+# Exclude development artifacts from the Docker build context
+.git
+.gitignore
+node_modules
+**/node_modules
+**/.parcel-cache
+**/dist
+coverage
+build
+e2e
+docs
+*.log
+npm-debug.log*

--- a/.github/workflows/master_contraction-timer-api.yml
+++ b/.github/workflows/master_contraction-timer-api.yml
@@ -1,4 +1,4 @@
-name: Build and deploy Node.js app to Azure Web App - contraction-timer-api
+name: Build and deploy Docker image to Azure Web App - contraction-timer-api
 
 on:
   push:
@@ -17,6 +17,11 @@ jobs:
         working-directory: server
     permissions:
       contents: read
+      packages: write
+    env:
+      IMAGE_NAME: contraction-timer-api
+    outputs:
+      image: ${{ steps.docker-publish.outputs.image }}
 
     steps:
       - uses: actions/checkout@v4
@@ -26,6 +31,7 @@ jobs:
         with:
           node-version: '22.x'
           cache: 'npm'
+          cache-dependency-path: 'server/package-lock.json'
 
       - name: Install dependencies
         run: npm ci
@@ -38,16 +44,22 @@ jobs:
       - name: Run tests
         run: npm test --if-present
 
-      - name: Create deployment archive
-        run: |
-          rm -rf node_modules .parcel-cache
-          zip -r ../contraction-timer-api.zip . -x "*.git*"
-
-      - name: Upload deployment artifact
-        uses: actions/upload-artifact@v4
+      - name: Log in to GitHub Container Registry
+        uses: docker/login-action@v3
         with:
-          name: node-app
-          path: contraction-timer-api.zip
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build and push Docker image
+        id: docker-publish
+        working-directory: ${{ github.workspace }}
+        run: |
+          OWNER="${GITHUB_REPOSITORY_OWNER,,}"
+          IMAGE_URI="ghcr.io/$OWNER/$IMAGE_NAME:${GITHUB_SHA}"
+          docker build -f server/Dockerfile -t "$IMAGE_URI" .
+          docker push "$IMAGE_URI"
+          echo "image=$IMAGE_URI" >> "$GITHUB_OUTPUT"
 
   deploy:
     runs-on: ubuntu-latest
@@ -57,12 +69,6 @@ jobs:
       contents: read
 
     steps:
-      - name: Download build artifact
-        uses: actions/download-artifact@v4
-        with:
-          name: node-app
-          path: ./node-app
-
       - name: Login to Azure
         uses: azure/login@v2
         with:
@@ -70,9 +76,44 @@ jobs:
           tenant-id: ${{ secrets.AZUREAPPSERVICE_TENANTID_498CE618BC8B4059BDF20BFB621955FA }}
           subscription-id: ${{ secrets.AZUREAPPSERVICE_SUBSCRIPTIONID_62B72743BD084628A81414BB1C47AA16 }}
 
-      - name: Deploy to Azure Web App
-        uses: azure/webapps-deploy@v3
-        with:
-          app-name: 'contraction-timer-api'
-          slot-name: 'Production'
-          package: node-app/contraction-timer-api.zip
+      - name: Configure Web App container image
+        env:
+          WEBAPP_NAME: contraction-timer-api
+          IMAGE_URI: ${{ needs.build.outputs.image }}
+        run: |
+          if [ -z "${{ secrets.GHCR_USERNAME }}" ] || [ -z "${{ secrets.GHCR_TOKEN }}" ]; then
+            echo "Secrets GHCR_USERNAME and GHCR_TOKEN must be configured with GitHub Container Registry credentials." >&2
+            exit 1
+          fi
+
+          RESOURCE_GROUP=$(az webapp show --name "$WEBAPP_NAME" --query resourceGroup -o tsv)
+          if [ -z "$RESOURCE_GROUP" ]; then
+            echo "Unable to determine resource group for $WEBAPP_NAME" >&2
+            exit 1
+          fi
+
+          SLOT_NAME="Production"
+          SLOT_EXISTS=$(az webapp deployment slot list --name "$WEBAPP_NAME" --resource-group "$RESOURCE_GROUP" --query "[?name=='$SLOT_NAME'].name" -o tsv)
+
+          if [ -n "$SLOT_EXISTS" ]; then
+            az webapp config container set \
+              --name "$WEBAPP_NAME" \
+              --resource-group "$RESOURCE_GROUP" \
+              --slot "$SLOT_NAME" \
+              --docker-custom-image-name "$IMAGE_URI" \
+              --docker-registry-server-url https://ghcr.io \
+              --docker-registry-server-user "${{ secrets.GHCR_USERNAME }}" \
+              --docker-registry-server-password "${{ secrets.GHCR_TOKEN }}"
+
+            az webapp restart --name "$WEBAPP_NAME" --resource-group "$RESOURCE_GROUP" --slot "$SLOT_NAME"
+          else
+            az webapp config container set \
+              --name "$WEBAPP_NAME" \
+              --resource-group "$RESOURCE_GROUP" \
+              --docker-custom-image-name "$IMAGE_URI" \
+              --docker-registry-server-url https://ghcr.io \
+              --docker-registry-server-user "${{ secrets.GHCR_USERNAME }}" \
+              --docker-registry-server-password "${{ secrets.GHCR_TOKEN }}"
+
+            az webapp restart --name "$WEBAPP_NAME" --resource-group "$RESOURCE_GROUP"
+          fi

--- a/server/Dockerfile
+++ b/server/Dockerfile
@@ -1,0 +1,38 @@
+# syntax=docker/dockerfile:1
+
+# Build stage: install dependencies and compile the server bundle
+FROM node:22-alpine AS build
+
+# Install dependencies in /app/server so relative imports resolve correctly
+WORKDIR /app/server
+
+# Install production and development dependencies
+COPY server/package*.json ./
+RUN npm ci
+
+# Copy the server source code
+COPY server/ ./
+# Copy shared client code that provides type definitions used by the server build
+COPY src/ ../src/
+
+# Build the compiled bundle and trim dev dependencies
+RUN NODE_OPTIONS=--openssl-legacy-provider npm run build && \
+    npm prune --omit=dev && \
+    rm -rf .parcel-cache
+
+# Runtime stage: copy the compiled application into a lean image
+FROM node:22-alpine AS runtime
+ENV NODE_ENV=production
+
+WORKDIR /app
+
+# Copy only the files required to run the server
+COPY --from=build /app/server/package.json ./
+COPY --from=build /app/server/node_modules ./node_modules
+COPY --from=build /app/server/dist ./dist
+
+# The server binds to the port provided via the PORT environment variable.
+# Azure App Service sets this automatically when running the container.
+EXPOSE 3001
+
+CMD ["node", "dist/main.js"]


### PR DESCRIPTION
## Summary
- add a multi-stage Dockerfile for the Socket.IO server and prune dev dependencies in the runtime image
- ignore development artifacts from the Docker build context
- update the Azure Web App workflow to publish the Docker image to GitHub Container Registry and configure the App Service to pull it with provided credentials

## Testing
- npm run build (server)


------
https://chatgpt.com/codex/tasks/task_e_68c94884b0e48328a70d320f68ba4c85