### PR TITLE
style: enhance welcome modal styling

### DIFF
--- a/src/components/welcome-modal/welcome-modal.component.tsx
+++ b/src/components/welcome-modal/welcome-modal.component.tsx
@@ -6,6 +6,21 @@ import { modalActions } from '../../store/modal/modal.slice';
 import { history } from '../../history';
 import { Copy } from '../copy/copy.component';
 import { buildBackendUrl } from '../../config/backend';
+import {
+  StyledContent,
+  StyledField,
+  StyledInput,
+  StyledLabel,
+  StyledLobbyButton,
+  StyledLobbyList,
+  StyledLobbyListItem,
+  StyledLobbySection,
+  StyledLobbySectionHeading,
+  StyledRoleFieldset,
+  StyledRoleLabel,
+  StyledRoleLegend,
+  StyledRoleOptions,
+} from './welcome-modal.styles';
 
 export const WelcomeModal: React.FC = () => {
   const dispatch = useDispatch();
@@ -40,53 +55,72 @@ export const WelcomeModal: React.FC = () => {
       secondaryButtonOnClick={handleCancel}
     >
       <Copy>
-        {/* eslint-disable-next-line jsx-a11y/label-has-associated-control */}
-        <label htmlFor="lobby-input">Lobby</label>
-        <input
-          id="lobby-input"
-          value={lobby}
-          onChange={(e) => setLobby(e.target.value)}
-          list="lobbies"
-        />
-        <datalist id="lobbies">
-          {lobbies.map((l) => (
-            <option key={l} value={l}>{l}</option>
-          ))}
-        </datalist>
-
-        {lobbies.length > 0 && (
-          <ul>
-            {lobbies.map((l) => (
-              <li key={l}>
-                <button type="button" onClick={() => setLobby(l)}>{l}</button>
-              </li>
-            ))}
-          </ul>
-        )}
-
-        <fieldset>
-          <legend>Role</legend>
-          <label htmlFor="role-recorder">
-            <input
-              id="role-recorder"
-              type="radio"
-              value="recorder"
-              checked={role === 'recorder'}
-              onChange={() => setRole('recorder')}
+        <StyledContent>
+          <StyledField>
+            {/* eslint-disable-next-line jsx-a11y/label-has-associated-control */}
+            <StyledLabel htmlFor="lobby-input">Lobby</StyledLabel>
+            <StyledInput
+              id="lobby-input"
+              value={lobby}
+              onChange={(e) => setLobby(e.target.value)}
+              list="lobbies"
             />
-            Recorder
-          </label>
-          <label htmlFor="role-monitor">
-            <input
-              id="role-monitor"
-              type="radio"
-              value="monitor"
-              checked={role === 'monitor'}
-              onChange={() => setRole('monitor')}
-            />
-            Monitor
-          </label>
-        </fieldset>
+            <datalist id="lobbies">
+              {lobbies.map((l) => (
+                <option key={l} value={l}>{l}</option>
+              ))}
+            </datalist>
+          </StyledField>
+
+          {lobbies.length > 0 && (
+            <StyledLobbySection>
+              <StyledLobbySectionHeading>
+                Or choose from an existing lobby
+              </StyledLobbySectionHeading>
+
+              <StyledLobbyList>
+                {lobbies.map((l) => (
+                  <StyledLobbyListItem key={l}>
+                    <StyledLobbyButton
+                      type="button"
+                      onClick={() => setLobby(l)}
+                      $selected={lobby === l}
+                      aria-pressed={lobby === l}
+                    >
+                      {l}
+                    </StyledLobbyButton>
+                  </StyledLobbyListItem>
+                ))}
+              </StyledLobbyList>
+            </StyledLobbySection>
+          )}
+
+          <StyledRoleFieldset>
+            <StyledRoleLegend>Role</StyledRoleLegend>
+            <StyledRoleOptions>
+              <StyledRoleLabel htmlFor="role-recorder" $selected={role === 'recorder'}>
+                <input
+                  id="role-recorder"
+                  type="radio"
+                  value="recorder"
+                  checked={role === 'recorder'}
+                  onChange={() => setRole('recorder')}
+                />
+                Recorder
+              </StyledRoleLabel>
+              <StyledRoleLabel htmlFor="role-monitor" $selected={role === 'monitor'}>
+                <input
+                  id="role-monitor"
+                  type="radio"
+                  value="monitor"
+                  checked={role === 'monitor'}
+                  onChange={() => setRole('monitor')}
+                />
+                Monitor
+              </StyledRoleLabel>
+            </StyledRoleOptions>
+          </StyledRoleFieldset>
+        </StyledContent>
       </Copy>
     </Modal>
   );

--- a/src/components/welcome-modal/welcome-modal.styles.tsx
+++ b/src/components/welcome-modal/welcome-modal.styles.tsx
@@ -1,0 +1,163 @@
+import {
+  borderRadius,
+  borderWidth,
+  color,
+  fontSize,
+  pxToRem,
+  spacing,
+  transitionDuration,
+} from '../../theme/helpers/theme.helpers';
+import styled from 'styled-components';
+
+export const StyledContent = styled.div`
+  display: flex;
+  flex-direction: column;
+
+  > * + * {
+    margin-top: ${spacing('l')};
+  }
+`;
+
+export const StyledField = styled.div`
+  display: flex;
+  flex-direction: column;
+
+  > * + * {
+    margin-top: ${spacing('s')};
+  }
+`;
+
+export const StyledLabel = styled.label`
+  color: ${color('neutralMid2')};
+  font-weight: bold;
+`;
+
+export const StyledInput = styled.input`
+  width: 100%;
+  padding: ${spacing('s')} ${spacing('m')};
+  transition: border-color ${transitionDuration('m')}, box-shadow ${transitionDuration('m')};
+  border: ${borderWidth('s')} solid ${color('neutralMax25')};
+  border-radius: ${borderRadius('s')};
+  background-color: ${color('neutralMin')};
+  color: ${color('neutralMid2')};
+
+  &:hover {
+    border-color: ${color('rest')};
+  }
+
+  &:focus-visible {
+    border-color: ${color('rest')};
+    outline: none;
+    box-shadow: 0 0 0 ${borderWidth('s')} ${color('rest')};
+  }
+`;
+
+export const StyledLobbySection = styled.section`
+  padding: ${spacing('m')};
+  border: ${borderWidth('s')} solid ${color('neutralMax25')};
+  border-radius: ${borderRadius('m')};
+  background-color: ${color('neutralMin')};
+  box-shadow: 0 ${pxToRem(4)} ${pxToRem(12)} ${color('neutralMax25')};
+
+  > * + * {
+    margin-top: ${spacing('m')};
+  }
+`;
+
+export const StyledLobbySectionHeading = styled.p`
+  margin: 0;
+  color: ${color('neutralMid1')};
+  font-size: ${fontSize('s')};
+  font-weight: bold;
+  letter-spacing: ${pxToRem(1)};
+  text-transform: uppercase;
+`;
+
+export const StyledLobbyList = styled.ul`
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(${pxToRem(140)}, 1fr));
+  gap: ${spacing('s')};
+  margin: 0;
+  padding: 0;
+  list-style: none;
+`;
+
+export const StyledLobbyListItem = styled.li`
+  display: flex;
+`;
+
+type LobbyButtonProps = {
+  $selected: boolean;
+};
+
+export const StyledLobbyButton = styled.button<LobbyButtonProps>`
+  flex: 1;
+  padding: ${spacing('m')};
+  transition: border-color ${transitionDuration('m')}, box-shadow ${transitionDuration('m')}, transform ${transitionDuration('m')};
+  border: ${borderWidth('s')} solid ${({ theme, $selected }) => ($selected ? theme.color.rest : theme.color.neutralMax25)};
+  border-radius: ${borderRadius('m')};
+  background-color: ${({ theme, $selected }) => ($selected ? theme.color.neutralMin75 : theme.color.neutralMin)};
+  box-shadow: ${({ theme, $selected }) => ($selected ? `0 ${pxToRem(4)} ${pxToRem(12)} ${theme.color.neutralMax25}` : 'none')};
+  color: ${color('neutralMid2')};
+  font-weight: bold;
+  text-align: center;
+  cursor: pointer;
+
+  &:hover,
+  &:focus-visible {
+    transform: translateY(-${pxToRem(2)});
+    border-color: ${({ theme }) => theme.color.rest};
+    outline: none;
+    box-shadow: 0 ${pxToRem(4)} ${pxToRem(12)} ${({ theme }) => theme.color.neutralMax25};
+  }
+
+  &:active {
+    transform: translateY(0);
+  }
+`;
+
+export const StyledRoleFieldset = styled.fieldset`
+  margin: 0;
+  padding: ${spacing('m')};
+  border: ${borderWidth('s')} solid ${color('neutralMax25')};
+  border-radius: ${borderRadius('m')};
+  background-color: ${color('neutralMin')};
+`;
+
+export const StyledRoleLegend = styled.legend`
+  margin: 0 0 ${spacing('s')};
+  color: ${color('neutralMid2')};
+  font-weight: bold;
+`;
+
+export const StyledRoleOptions = styled.div`
+  display: flex;
+  flex-wrap: wrap;
+  gap: ${spacing('s')};
+`;
+
+type RoleLabelProps = {
+  $selected: boolean;
+};
+
+export const StyledRoleLabel = styled.label<RoleLabelProps>`
+  display: inline-flex;
+  align-items: center;
+  gap: ${spacing('s')};
+  padding: ${spacing('s')} ${spacing('m')};
+  transition: border-color ${transitionDuration('m')}, background-color ${transitionDuration('m')};
+  border: ${borderWidth('s')} solid ${({ theme, $selected }) => ($selected ? theme.color.rest : theme.color.neutralMax25)};
+  border-radius: ${borderRadius('xl')};
+  background-color: ${({ theme, $selected }) => ($selected ? theme.color.neutralMin75 : theme.color.neutralMin)};
+  color: ${color('neutralMid2')};
+  cursor: pointer;
+
+  input {
+    margin: 0;
+  }
+
+  &:hover,
+  &:focus-within {
+    border-color: ${({ theme }) => theme.color.rest};
+  }
+`;

--- a/src/store/app.store.ts
+++ b/src/store/app.store.ts
@@ -8,8 +8,12 @@ import { createSocketMiddleware } from './socket.middleware';
 export const createStore = (history: History, persist: boolean) => {
   const segments = history.location.pathname.split('/').filter(Boolean);
   const lobby = segments[0];
+  const storageKey = lobby ? `redux:${lobby}` : 'redux:default';
   // Type definitions are incorrect, use 'any' to bypass (https://github.com/elgerlambert/redux-localstorage/issues/78)
-  const persistStateEnhancer: any = persistState(['timer', lobby ? `${lobby}` : 'default'] as any);
+  const persistStateEnhancer: any = persistState(
+    ['timer', lobby ? `${lobby}` : 'default'] as any,
+    { key: storageKey } as any
+  );
 
   return configureStore({
     reducer: rootReducer,


### PR DESCRIPTION
## Summary
- restyle the welcome modal to use dedicated styled components for the lobby selector and role options.
- add a welcome-modal styles module that highlights available lobbies and selected roles for easier joining.
- ensure persisted lobby state uses a lobby-specific storage key when enabling persistence.

## Testing
- npm run lint
- npm run lint:css
- CI=true npm test

------
https://chatgpt.com/codex/tasks/task_e_68c9ab22374083288b17cb7700dc00bf